### PR TITLE
Update opauth config

### DIFF
--- a/src/config/opauth.php
+++ b/src/config/opauth.php
@@ -3,13 +3,13 @@
 	// OAuth paths
 	//////////////////////////////////////////////////////////////////////
 
-	'path'           => '/_github/flickering/example/',
-	'callback_url'   => '{path}flickr/callback',
+	'path'           => '/',
+	'callback_url'   => '{path}flickr/oauth_callback',
 	'oauth_callback' => '{path}',
 
 	// Security salt
 	//////////////////////////////////////////////////////////////////////
 
-	'security_salt'  => 'LDFmfiilYf8Fyw5W10rx4W1KsVrieQCnpBzzpTBWA5vJidQKDx8pMJbmw28R1C4m',
+	'security_salt'  => 'LDFmiilYf8Fyw5W10rx4W1KsVrieQCnpBzzpTBWA5vJidQKDx8pMJbmw28R1C4m',
 
 );


### PR DESCRIPTION
The path was a bit strange as a default?
Tweaked the callback for the example (coming in next commit)
Security salt is now the same as the default in opauth, because this is checked. This forces people to change the key.
