### PR TITLE
Update opauth/flickr requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "illuminate/container": "~4",
     "illuminate/http": "~4",
     "illuminate/support": "~4",
-    "opauth/flickr": "*",
+    "opauth/flickr": "~1",
     "themattharris/tmhOAuth": "0.8.x"
   },
   "require-dev": {


### PR DESCRIPTION
Could you tag a new release after this? So we can require a stable version.
