### PR TITLE
Fix for disabling caching.

### DIFF
--- a/src/Flickering/Request.php
+++ b/src/Flickering/Request.php
@@ -150,7 +150,7 @@ class Request
 	{
 		// If cache disabled, always return false
 		if (!$this->app['config']->get('flickering::config.cache.cache_requests')) {
-			return 0;
+			return null;
 		}
 
 		return (int) $this->app['config']->get('flickering::config.cache.lifetime');


### PR DESCRIPTION
This fixes the option to disable caching. The code used to set the cache time to 0 minutes, which makes the default Laravel cache FileStore save it for 9999999999 minutes. 
By settings the time to null, it will never cache.