### PR TITLE
Fixed security issue for authentified queries.

### DIFF
--- a/src/Flickering/Request.php
+++ b/src/Flickering/Request.php
@@ -175,6 +175,10 @@ class Request
             $hash[] = $k.'-'.$v;
         }
 
+        if ($this->user) {
+            $hash[] = $this->user->getUid();
+        }
+
         return implode('-', $hash);
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -13,7 +13,7 @@ class RequestTest extends FlickeringTestCase
             'bis' => 'ter',
         ));
 
-        $this->assertEquals('bis-ter-foo-bar', $request->getHash());
+        $this->assertEquals('bis-ter-foo-bar-00000000000@N01', $request->getHash());
     }
 
     public function testCacheTimeIsZeroIfCacheDisabled()

--- a/tests/TestCases/FlickeringTestCase.php
+++ b/tests/TestCases/FlickeringTestCase.php
@@ -87,7 +87,8 @@ abstract class FlickeringTestCase extends PHPUnit_Framework_TestCase
             'credentials' => array(
                 'token'  => 'foo',
                 'secret' => 'bar'
-            )
+            ),
+            'uid' => '00000000000@N01'
         ));
     }
 


### PR DESCRIPTION
Hi,

When I query Flickr with an authentified user, the package caches the query but for all users. So every user will see the photos of the first user which made the first cached query.

Now the cache is also based in UID.
